### PR TITLE
fix: end of file in offsetless streams

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -9,7 +9,6 @@ on:
     paths: ["**.php"]
     branches: ["main"]
 
-
 env:
   COMPOSER_FLAGS: "--ansi --no-interaction --no-progress --no-suggest --ignore-platform-req=php"
 

--- a/src/ResourceHelper.php
+++ b/src/ResourceHelper.php
@@ -67,6 +67,11 @@ trait ResourceHelper
         }
         $bytes = fread($this->resource, $length);
         if (!is_string($bytes)) {
+            // Covers edge cases when underlying stream detects EOF after reads
+            // This is true of most network streams as they don't know the file size in advance
+            if (feof($this->resource)) {
+                throw new EndOfFile('Could not read bytes: End of file reached');
+            }
             throw new Error('Could not read bytes: Unknown error.');
         }
 

--- a/tests/BufferTest.php
+++ b/tests/BufferTest.php
@@ -23,7 +23,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @internal
  *
- * @coversNothing
+ * @covers \Castor\Io\Buffer
  */
 class BufferTest extends TestCase
 {


### PR DESCRIPTION
Some streams may declare eof after a file read because they don't know the full length of the stream.